### PR TITLE
Manage CHANGELOG with chg(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,22 @@
-## 0.17.4 (Unreleased)
+CHANGELOG
+=========
 
-## 0.17.3 (Released 28th May, 2019)
+## HEAD (Unreleased)
+_(none)_
 
-### Improvements
+---
 
-- Fixed a bug where configuration was required for the default provider instance
-  even in cases where only first-class providers were in use.
+## 0.17.3 (2019-05-28)
+* Fix a bug where configuration is erroneously required for default provider instances even in cases where only first-class provider instances are in use
+* Update to v1.15.0 of the Cloudflare Terraform provider
 
-- Updated to v1.15.0 of the upstream Cloudflare Terraform provider.
+## 0.17.2 (2019-05-16)
+* Update to v1.14.0 of the Cloudflare Terraform provider
+* Add an example of Cloudflare Workers
 
-## 0.17.2 (Released 16th May, 2019)
+## 0.17.1 (2019-05-06)
+* Update to v1.13.0 of the Cloudflare Terraform provider
 
-### Improvements
+## 0.17.0 (2019-03-08)
+* Initial version of the Cloudflare provider, based on v1.12.0 of the Cloudflare Terraform provider
 
-- Updated to the v1.14.0 of the upstream Cloudflare Terraform provider
-
-### Examples
-
-- Added a Worker example
-
-
-## 0.17.1 (Released 6th May, 2019)
-
-### Improvements
-
-- Updated to the v1.13.0 of the upstream Cloudflare Terraform provider
-
-## 0.17.0 (Released 8th March, 2019)
-
-- First version of Cloudflare provider, based on the Cloudflare Terraform provider v1.12.0


### PR DESCRIPTION
This commit reformats the CHANGELOG.md file to be in format which can be managed using https://github.com/heff/chg/, in order to make it manageable from scripts.