### PR TITLE
Update pulumi-terraform to 65eb36cfeb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/miekg/dns v1.0.14 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d
+	github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/terraform-providers/terraform-provider-cloudflare v1.16.0
 )

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/pulumi/pulumi-terraform v0.18.2-0.20190522154113-c2798a1b001d/go.mod 
 github.com/pulumi/pulumi-terraform v0.18.2 h1:87eFAASBmHCH41OlcGZAydGgSYFTIPFoKjzaJ8Edw5M=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d h1:ObOJbSfTnJ8IzrTw7pVcckU+R0yMEyV4mXdQ+xH+j8w=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
+github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1 h1:T9LXyH3t0tAwDowydQDIntfLEsPsowtmzZd7Z/6YAIw=
+github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -19,13 +19,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-   $ npm install @pulumi/cloudflare
+    $ npm install @pulumi/cloudflare
 
 or ``yarn``:
 
 ::
 
-   $ yarn add @pulumi/cloudflare
+    $ yarn add @pulumi/cloudflare
 
 Python
 ~~~~~~
@@ -34,7 +34,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-   $ pip install pulumi_cloudflare
+    $ pip install pulumi_cloudflare
 
 Go
 ~~
@@ -43,7 +43,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-   $ go get github.com/pulumi/pulumi-cloudflare/sdk/go/...
+    $ go get github.com/pulumi/pulumi-cloudflare/sdk/go/...
 
 Reference
 ---------


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [65eb36cfeb](https://github.com/pulumi/pulumi-terraform/commit/65eb36cfebb1c6261d1859e75b33fd01b90cbba0), and re-runs code generation