### PR TITLE
Clean up upstream removed data sources, rebuild

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+
 	// embed allows embedding files
 	_ "embed"
 
@@ -262,13 +263,10 @@ func Provider() tfbridge.ProviderInfo {
 			"cloudflare_origin_ca_root_certificate": {
 				Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getOriginCaRootCertificate"),
 			},
-			"cloudflare_record":       {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getRecord")},
-			"cloudflare_waf_groups":   {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getWafGroups")},
-			"cloudflare_waf_packages": {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getWafPackages")},
-			"cloudflare_waf_rules":    {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getWafRules")},
-			"cloudflare_zone":         {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getZone")},
-			"cloudflare_zone_dnssec":  {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getZoneDnssec")},
-			"cloudflare_zones":        {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getZones")},
+			"cloudflare_record":      {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getRecord")},
+			"cloudflare_zone":        {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getZone")},
+			"cloudflare_zone_dnssec": {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getZoneDnssec")},
+			"cloudflare_zones":       {Tok: tfbridge.MakeDataSource(mainPkg, mainMod, "getZones")},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Fcloudflare.svg)](https://www.npmjs.com/package/@pulumi/cloudflare)
 [![Python version](https://badge.fury.io/py/pulumi-cloudflare.svg)](https://pypi.org/project/pulumi-cloudflare)
 [![NuGet version](https://badge.fury.io/nu/pulumi.cloudflare.svg)](https://badge.fury.io/nu/pulumi.cloudflare)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-cloudflare/sdk/v3/go)](https://pkg.go.dev/github.com/pulumi/pulumi-cloudflare/sdk/v3/go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare)](https://pkg.go.dev/github.com/pulumi/pulumi-cloudflare/sdk/v5/go/cloudflare)
 [![License](https://img.shields.io/npm/l/%40pulumi%2Fpulumi.svg)](https://github.com/pulumi/pulumi-cloudflare/blob/master/LICENSE)
 
 # Cloudflare Provider


### PR DESCRIPTION
Unblock releasing 5.3.0, which failed due to a diff on README early on in the release process, see:
* [5.3.0 release workflow](https://github.com/pulumi/pulumi-cloudflare/actions/runs/5145616457)
* [5.4.0 release workflow](https://github.com/pulumi/pulumi-cloudflare/actions/runs/5246057254)

And may have failed during tfgen as well with:

```
error: failed to gather package metadata: problem gathering data sources: 3 errors occurred:
        * Pulumi token "cloudflare:index/getWafGroups:getWafGroups" is mapped to TF provider data source "cloudflare_waf_groups", but no such data source found. Remove the mapping and try again
        * Pulumi token "cloudflare:index/getWafPackages:getWafPackages" is mapped to TF provider data source "cloudflare_waf_packages", but no such data source found. Remove the mapping and try again
        * Pulumi token "cloudflare:index/getWafRules:getWafRules" is mapped to TF provider data source "cloudflare_waf_rules", but no such data source found. Remove the mapping and try again
```

