### PR TITLE
Enable zero default schema version

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -183,6 +183,7 @@ func Provider() tfbridge.ProviderInfo {
 				mainPkg: "Cloudflare",
 			},
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	prov.MustComputeTokens(tfbridgetokens.SingleModule("cloudflare_", mainMod,


### PR DESCRIPTION
Roll out https://github.com/pulumi/pulumi-terraform-bridge/pull/2081 to cloudflare.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133