### PR TITLE
Update type of PagesProjectSource.type

### DIFF
--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -3693,7 +3693,7 @@ export interface PagesProjectSource {
     /**
      * Project host type.
      */
-    type?: pulumi.Input<string>;
+    type?: pulumi.Input<"github" | "gitlab">;
 }
 
 export interface PagesProjectSourceConfig {


### PR DESCRIPTION
Do you think that the type of PagesProjectSource needs to be specified exactly like this? I don't see any valid value in the documentation. I have to run the stack to get the valid values for the first run.