### PR TITLE
Hyperdrive config remap id

### DIFF
--- a/provider/cmd/pulumi-resource-cloudflare/schema.json
+++ b/provider/cmd/pulumi-resource-cloudflare/schema.json
@@ -20227,11 +20227,16 @@
                 "origin": {
                     "$ref": "#/types/cloudflare:index/HyperdriveConfigOrigin:HyperdriveConfigOrigin",
                     "description": "The origin details for the Hyperdrive configuration.\n"
+                },
+                "resourceId": {
+                    "type": "string",
+                    "description": "The identifier of this resource. This is the hyperdrive config value.\n"
                 }
             },
             "required": [
                 "accountId",
                 "caching",
+                "resourceId",
                 "name",
                 "origin"
             ],
@@ -20251,6 +20256,10 @@
                 "origin": {
                     "$ref": "#/types/cloudflare:index/HyperdriveConfigOrigin:HyperdriveConfigOrigin",
                     "description": "The origin details for the Hyperdrive configuration.\n"
+                },
+                "resourceId": {
+                    "type": "string",
+                    "description": "The identifier of this resource. This is the hyperdrive config value.\n"
                 }
             },
             "requiredInputs": [
@@ -20276,6 +20285,10 @@
                     "origin": {
                         "$ref": "#/types/cloudflare:index/HyperdriveConfigOrigin:HyperdriveConfigOrigin",
                         "description": "The origin details for the Hyperdrive configuration.\n"
+                    },
+                    "resourceId": {
+                        "type": "string",
+                        "description": "The identifier of this resource. This is the hyperdrive config value.\n"
                     }
                 },
                 "type": "object"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -136,8 +136,15 @@ func Provider() tfbridge.ProviderInfo {
 			//
 			// Set our ID as site Key, which is what it represents upstream:
 			// <https://developers.cloudflare.com/turnstile/get-started/terraform/#create-a-turnstile-widget>.
-			"cloudflare_turnstile_widget":      {ComputeID: delegateID("id")},
-			"cloudflare_hyperdrive_config":     {ComputeID: delegateID("accountId")},
+			"cloudflare_turnstile_widget": {ComputeID: delegateID("id")},
+			"cloudflare_hyperdrive_config": {
+				ComputeID: delegateID("accountId"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"id": {
+						Name: "resourceId",
+					},
+				},
+			},
 			"cloudflare_cloud_connector_rules": {ComputeID: delegateID("zoneId")},
 			// cloudflare_access_mutual_tls_hostname_settings has no ID or canonical ID field.
 			"cloudflare_access_mutual_tls_hostname_settings": {

--- a/sdk/dotnet/HyperdriveConfig.cs
+++ b/sdk/dotnet/HyperdriveConfig.cs
@@ -73,6 +73,12 @@ namespace Pulumi.Cloudflare
         [Output("origin")]
         public Output<Outputs.HyperdriveConfigOrigin> Origin { get; private set; } = null!;
 
+        /// <summary>
+        /// The identifier of this resource. This is the hyperdrive config value.
+        /// </summary>
+        [Output("resourceId")]
+        public Output<string> ResourceId { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a HyperdriveConfig resource with the given unique name, arguments, and options.
@@ -143,6 +149,12 @@ namespace Pulumi.Cloudflare
         [Input("origin", required: true)]
         public Input<Inputs.HyperdriveConfigOriginArgs> Origin { get; set; } = null!;
 
+        /// <summary>
+        /// The identifier of this resource. This is the hyperdrive config value.
+        /// </summary>
+        [Input("resourceId")]
+        public Input<string>? ResourceId { get; set; }
+
         public HyperdriveConfigArgs()
         {
         }
@@ -174,6 +186,12 @@ namespace Pulumi.Cloudflare
         /// </summary>
         [Input("origin")]
         public Input<Inputs.HyperdriveConfigOriginGetArgs>? Origin { get; set; }
+
+        /// <summary>
+        /// The identifier of this resource. This is the hyperdrive config value.
+        /// </summary>
+        [Input("resourceId")]
+        public Input<string>? ResourceId { get; set; }
 
         public HyperdriveConfigState()
         {

--- a/sdk/go/cloudflare/hyperdriveConfig.go
+++ b/sdk/go/cloudflare/hyperdriveConfig.go
@@ -65,6 +65,8 @@ type HyperdriveConfig struct {
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The origin details for the Hyperdrive configuration.
 	Origin HyperdriveConfigOriginOutput `pulumi:"origin"`
+	// The identifier of this resource. This is the hyperdrive config value.
+	ResourceId pulumi.StringOutput `pulumi:"resourceId"`
 }
 
 // NewHyperdriveConfig registers a new resource with the given unique name, arguments, and options.
@@ -114,6 +116,8 @@ type hyperdriveConfigState struct {
 	Name *string `pulumi:"name"`
 	// The origin details for the Hyperdrive configuration.
 	Origin *HyperdriveConfigOrigin `pulumi:"origin"`
+	// The identifier of this resource. This is the hyperdrive config value.
+	ResourceId *string `pulumi:"resourceId"`
 }
 
 type HyperdriveConfigState struct {
@@ -125,6 +129,8 @@ type HyperdriveConfigState struct {
 	Name pulumi.StringPtrInput
 	// The origin details for the Hyperdrive configuration.
 	Origin HyperdriveConfigOriginPtrInput
+	// The identifier of this resource. This is the hyperdrive config value.
+	ResourceId pulumi.StringPtrInput
 }
 
 func (HyperdriveConfigState) ElementType() reflect.Type {
@@ -140,6 +146,8 @@ type hyperdriveConfigArgs struct {
 	Name string `pulumi:"name"`
 	// The origin details for the Hyperdrive configuration.
 	Origin HyperdriveConfigOrigin `pulumi:"origin"`
+	// The identifier of this resource. This is the hyperdrive config value.
+	ResourceId *string `pulumi:"resourceId"`
 }
 
 // The set of arguments for constructing a HyperdriveConfig resource.
@@ -152,6 +160,8 @@ type HyperdriveConfigArgs struct {
 	Name pulumi.StringInput
 	// The origin details for the Hyperdrive configuration.
 	Origin HyperdriveConfigOriginInput
+	// The identifier of this resource. This is the hyperdrive config value.
+	ResourceId pulumi.StringPtrInput
 }
 
 func (HyperdriveConfigArgs) ElementType() reflect.Type {
@@ -259,6 +269,11 @@ func (o HyperdriveConfigOutput) Name() pulumi.StringOutput {
 // The origin details for the Hyperdrive configuration.
 func (o HyperdriveConfigOutput) Origin() HyperdriveConfigOriginOutput {
 	return o.ApplyT(func(v *HyperdriveConfig) HyperdriveConfigOriginOutput { return v.Origin }).(HyperdriveConfigOriginOutput)
+}
+
+// The identifier of this resource. This is the hyperdrive config value.
+func (o HyperdriveConfigOutput) ResourceId() pulumi.StringOutput {
+	return o.ApplyT(func(v *HyperdriveConfig) pulumi.StringOutput { return v.ResourceId }).(pulumi.StringOutput)
 }
 
 type HyperdriveConfigArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/cloudflare/HyperdriveConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/cloudflare/HyperdriveConfig.java
@@ -128,6 +128,20 @@ public class HyperdriveConfig extends com.pulumi.resources.CustomResource {
     public Output<HyperdriveConfigOrigin> origin() {
         return this.origin;
     }
+    /**
+     * The identifier of this resource. This is the hyperdrive config value.
+     * 
+     */
+    @Export(name="resourceId", refs={String.class}, tree="[0]")
+    private Output<String> resourceId;
+
+    /**
+     * @return The identifier of this resource. This is the hyperdrive config value.
+     * 
+     */
+    public Output<String> resourceId() {
+        return this.resourceId;
+    }
 
     /**
      *

--- a/sdk/java/src/main/java/com/pulumi/cloudflare/HyperdriveConfigArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/cloudflare/HyperdriveConfigArgs.java
@@ -78,6 +78,21 @@ public final class HyperdriveConfigArgs extends com.pulumi.resources.ResourceArg
         return this.origin;
     }
 
+    /**
+     * The identifier of this resource. This is the hyperdrive config value.
+     * 
+     */
+    @Import(name="resourceId")
+    private @Nullable Output<String> resourceId;
+
+    /**
+     * @return The identifier of this resource. This is the hyperdrive config value.
+     * 
+     */
+    public Optional<Output<String>> resourceId() {
+        return Optional.ofNullable(this.resourceId);
+    }
+
     private HyperdriveConfigArgs() {}
 
     private HyperdriveConfigArgs(HyperdriveConfigArgs $) {
@@ -85,6 +100,7 @@ public final class HyperdriveConfigArgs extends com.pulumi.resources.ResourceArg
         this.caching = $.caching;
         this.name = $.name;
         this.origin = $.origin;
+        this.resourceId = $.resourceId;
     }
 
     public static Builder builder() {
@@ -187,6 +203,27 @@ public final class HyperdriveConfigArgs extends com.pulumi.resources.ResourceArg
          */
         public Builder origin(HyperdriveConfigOriginArgs origin) {
             return origin(Output.of(origin));
+        }
+
+        /**
+         * @param resourceId The identifier of this resource. This is the hyperdrive config value.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder resourceId(@Nullable Output<String> resourceId) {
+            $.resourceId = resourceId;
+            return this;
+        }
+
+        /**
+         * @param resourceId The identifier of this resource. This is the hyperdrive config value.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder resourceId(String resourceId) {
+            return resourceId(Output.of(resourceId));
         }
 
         public HyperdriveConfigArgs build() {

--- a/sdk/java/src/main/java/com/pulumi/cloudflare/inputs/HyperdriveConfigState.java
+++ b/sdk/java/src/main/java/com/pulumi/cloudflare/inputs/HyperdriveConfigState.java
@@ -77,6 +77,21 @@ public final class HyperdriveConfigState extends com.pulumi.resources.ResourceAr
         return Optional.ofNullable(this.origin);
     }
 
+    /**
+     * The identifier of this resource. This is the hyperdrive config value.
+     * 
+     */
+    @Import(name="resourceId")
+    private @Nullable Output<String> resourceId;
+
+    /**
+     * @return The identifier of this resource. This is the hyperdrive config value.
+     * 
+     */
+    public Optional<Output<String>> resourceId() {
+        return Optional.ofNullable(this.resourceId);
+    }
+
     private HyperdriveConfigState() {}
 
     private HyperdriveConfigState(HyperdriveConfigState $) {
@@ -84,6 +99,7 @@ public final class HyperdriveConfigState extends com.pulumi.resources.ResourceAr
         this.caching = $.caching;
         this.name = $.name;
         this.origin = $.origin;
+        this.resourceId = $.resourceId;
     }
 
     public static Builder builder() {
@@ -186,6 +202,27 @@ public final class HyperdriveConfigState extends com.pulumi.resources.ResourceAr
          */
         public Builder origin(HyperdriveConfigOriginArgs origin) {
             return origin(Output.of(origin));
+        }
+
+        /**
+         * @param resourceId The identifier of this resource. This is the hyperdrive config value.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder resourceId(@Nullable Output<String> resourceId) {
+            $.resourceId = resourceId;
+            return this;
+        }
+
+        /**
+         * @param resourceId The identifier of this resource. This is the hyperdrive config value.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder resourceId(String resourceId) {
+            return resourceId(Output.of(resourceId));
         }
 
         public HyperdriveConfigState build() {

--- a/sdk/nodejs/hyperdriveConfig.ts
+++ b/sdk/nodejs/hyperdriveConfig.ts
@@ -79,6 +79,10 @@ export class HyperdriveConfig extends pulumi.CustomResource {
      * The origin details for the Hyperdrive configuration.
      */
     public readonly origin!: pulumi.Output<outputs.HyperdriveConfigOrigin>;
+    /**
+     * The identifier of this resource. This is the hyperdrive config value.
+     */
+    public readonly resourceId!: pulumi.Output<string>;
 
     /**
      * Create a HyperdriveConfig resource with the given unique name, arguments, and options.
@@ -97,6 +101,7 @@ export class HyperdriveConfig extends pulumi.CustomResource {
             resourceInputs["caching"] = state ? state.caching : undefined;
             resourceInputs["name"] = state ? state.name : undefined;
             resourceInputs["origin"] = state ? state.origin : undefined;
+            resourceInputs["resourceId"] = state ? state.resourceId : undefined;
         } else {
             const args = argsOrState as HyperdriveConfigArgs | undefined;
             if ((!args || args.accountId === undefined) && !opts.urn) {
@@ -112,6 +117,7 @@ export class HyperdriveConfig extends pulumi.CustomResource {
             resourceInputs["caching"] = args ? args.caching : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["origin"] = args ? args.origin : undefined;
+            resourceInputs["resourceId"] = args ? args.resourceId : undefined;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(HyperdriveConfig.__pulumiType, name, resourceInputs, opts);
@@ -138,6 +144,10 @@ export interface HyperdriveConfigState {
      * The origin details for the Hyperdrive configuration.
      */
     origin?: pulumi.Input<inputs.HyperdriveConfigOrigin>;
+    /**
+     * The identifier of this resource. This is the hyperdrive config value.
+     */
+    resourceId?: pulumi.Input<string>;
 }
 
 /**
@@ -160,4 +170,8 @@ export interface HyperdriveConfigArgs {
      * The origin details for the Hyperdrive configuration.
      */
     origin: pulumi.Input<inputs.HyperdriveConfigOrigin>;
+    /**
+     * The identifier of this resource. This is the hyperdrive config value.
+     */
+    resourceId?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_cloudflare/hyperdrive_config.py
+++ b/sdk/python/pulumi_cloudflare/hyperdrive_config.py
@@ -24,19 +24,23 @@ class HyperdriveConfigArgs:
                  account_id: pulumi.Input[str],
                  name: pulumi.Input[str],
                  origin: pulumi.Input['HyperdriveConfigOriginArgs'],
-                 caching: Optional[pulumi.Input['HyperdriveConfigCachingArgs']] = None):
+                 caching: Optional[pulumi.Input['HyperdriveConfigCachingArgs']] = None,
+                 resource_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a HyperdriveConfig resource.
         :param pulumi.Input[str] account_id: The account identifier to target for the resource.
         :param pulumi.Input[str] name: The name of the Hyperdrive configuration.
         :param pulumi.Input['HyperdriveConfigOriginArgs'] origin: The origin details for the Hyperdrive configuration.
         :param pulumi.Input['HyperdriveConfigCachingArgs'] caching: The caching details for the Hyperdrive configuration.
+        :param pulumi.Input[str] resource_id: The identifier of this resource. This is the hyperdrive config value.
         """
         pulumi.set(__self__, "account_id", account_id)
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "origin", origin)
         if caching is not None:
             pulumi.set(__self__, "caching", caching)
+        if resource_id is not None:
+            pulumi.set(__self__, "resource_id", resource_id)
 
     @property
     @pulumi.getter(name="accountId")
@@ -86,6 +90,18 @@ class HyperdriveConfigArgs:
     def caching(self, value: Optional[pulumi.Input['HyperdriveConfigCachingArgs']]):
         pulumi.set(self, "caching", value)
 
+    @property
+    @pulumi.getter(name="resourceId")
+    def resource_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The identifier of this resource. This is the hyperdrive config value.
+        """
+        return pulumi.get(self, "resource_id")
+
+    @resource_id.setter
+    def resource_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "resource_id", value)
+
 
 @pulumi.input_type
 class _HyperdriveConfigState:
@@ -93,13 +109,15 @@ class _HyperdriveConfigState:
                  account_id: Optional[pulumi.Input[str]] = None,
                  caching: Optional[pulumi.Input['HyperdriveConfigCachingArgs']] = None,
                  name: Optional[pulumi.Input[str]] = None,
-                 origin: Optional[pulumi.Input['HyperdriveConfigOriginArgs']] = None):
+                 origin: Optional[pulumi.Input['HyperdriveConfigOriginArgs']] = None,
+                 resource_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering HyperdriveConfig resources.
         :param pulumi.Input[str] account_id: The account identifier to target for the resource.
         :param pulumi.Input['HyperdriveConfigCachingArgs'] caching: The caching details for the Hyperdrive configuration.
         :param pulumi.Input[str] name: The name of the Hyperdrive configuration.
         :param pulumi.Input['HyperdriveConfigOriginArgs'] origin: The origin details for the Hyperdrive configuration.
+        :param pulumi.Input[str] resource_id: The identifier of this resource. This is the hyperdrive config value.
         """
         if account_id is not None:
             pulumi.set(__self__, "account_id", account_id)
@@ -109,6 +127,8 @@ class _HyperdriveConfigState:
             pulumi.set(__self__, "name", name)
         if origin is not None:
             pulumi.set(__self__, "origin", origin)
+        if resource_id is not None:
+            pulumi.set(__self__, "resource_id", resource_id)
 
     @property
     @pulumi.getter(name="accountId")
@@ -158,6 +178,18 @@ class _HyperdriveConfigState:
     def origin(self, value: Optional[pulumi.Input['HyperdriveConfigOriginArgs']]):
         pulumi.set(self, "origin", value)
 
+    @property
+    @pulumi.getter(name="resourceId")
+    def resource_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The identifier of this resource. This is the hyperdrive config value.
+        """
+        return pulumi.get(self, "resource_id")
+
+    @resource_id.setter
+    def resource_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "resource_id", value)
+
 
 class HyperdriveConfig(pulumi.CustomResource):
     @overload
@@ -168,6 +200,7 @@ class HyperdriveConfig(pulumi.CustomResource):
                  caching: Optional[pulumi.Input[Union['HyperdriveConfigCachingArgs', 'HyperdriveConfigCachingArgsDict']]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  origin: Optional[pulumi.Input[Union['HyperdriveConfigOriginArgs', 'HyperdriveConfigOriginArgsDict']]] = None,
+                 resource_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         The [Hyperdrive Config](https://developers.cloudflare.com/hyperdrive/) resource allows you to manage Cloudflare Hyperdrive Configs.
@@ -203,6 +236,7 @@ class HyperdriveConfig(pulumi.CustomResource):
         :param pulumi.Input[Union['HyperdriveConfigCachingArgs', 'HyperdriveConfigCachingArgsDict']] caching: The caching details for the Hyperdrive configuration.
         :param pulumi.Input[str] name: The name of the Hyperdrive configuration.
         :param pulumi.Input[Union['HyperdriveConfigOriginArgs', 'HyperdriveConfigOriginArgsDict']] origin: The origin details for the Hyperdrive configuration.
+        :param pulumi.Input[str] resource_id: The identifier of this resource. This is the hyperdrive config value.
         """
         ...
     @overload
@@ -257,6 +291,7 @@ class HyperdriveConfig(pulumi.CustomResource):
                  caching: Optional[pulumi.Input[Union['HyperdriveConfigCachingArgs', 'HyperdriveConfigCachingArgsDict']]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  origin: Optional[pulumi.Input[Union['HyperdriveConfigOriginArgs', 'HyperdriveConfigOriginArgsDict']]] = None,
+                 resource_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -276,6 +311,7 @@ class HyperdriveConfig(pulumi.CustomResource):
             if origin is None and not opts.urn:
                 raise TypeError("Missing required property 'origin'")
             __props__.__dict__["origin"] = origin
+            __props__.__dict__["resource_id"] = resource_id
         super(HyperdriveConfig, __self__).__init__(
             'cloudflare:index/hyperdriveConfig:HyperdriveConfig',
             resource_name,
@@ -289,7 +325,8 @@ class HyperdriveConfig(pulumi.CustomResource):
             account_id: Optional[pulumi.Input[str]] = None,
             caching: Optional[pulumi.Input[Union['HyperdriveConfigCachingArgs', 'HyperdriveConfigCachingArgsDict']]] = None,
             name: Optional[pulumi.Input[str]] = None,
-            origin: Optional[pulumi.Input[Union['HyperdriveConfigOriginArgs', 'HyperdriveConfigOriginArgsDict']]] = None) -> 'HyperdriveConfig':
+            origin: Optional[pulumi.Input[Union['HyperdriveConfigOriginArgs', 'HyperdriveConfigOriginArgsDict']]] = None,
+            resource_id: Optional[pulumi.Input[str]] = None) -> 'HyperdriveConfig':
         """
         Get an existing HyperdriveConfig resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -301,6 +338,7 @@ class HyperdriveConfig(pulumi.CustomResource):
         :param pulumi.Input[Union['HyperdriveConfigCachingArgs', 'HyperdriveConfigCachingArgsDict']] caching: The caching details for the Hyperdrive configuration.
         :param pulumi.Input[str] name: The name of the Hyperdrive configuration.
         :param pulumi.Input[Union['HyperdriveConfigOriginArgs', 'HyperdriveConfigOriginArgsDict']] origin: The origin details for the Hyperdrive configuration.
+        :param pulumi.Input[str] resource_id: The identifier of this resource. This is the hyperdrive config value.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -310,6 +348,7 @@ class HyperdriveConfig(pulumi.CustomResource):
         __props__.__dict__["caching"] = caching
         __props__.__dict__["name"] = name
         __props__.__dict__["origin"] = origin
+        __props__.__dict__["resource_id"] = resource_id
         return HyperdriveConfig(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -343,4 +382,12 @@ class HyperdriveConfig(pulumi.CustomResource):
         The origin details for the Hyperdrive configuration.
         """
         return pulumi.get(self, "origin")
+
+    @property
+    @pulumi.getter(name="resourceId")
+    def resource_id(self) -> pulumi.Output[str]:
+        """
+        The identifier of this resource. This is the hyperdrive config value.
+        """
+        return pulumi.get(self, "resource_id")
 


### PR DESCRIPTION
Remaps the TF ID field of the hyperdrive config resource so that we do not clobber it with ComputeID

fixes https://github.com/pulumi/pulumi-cloudflare/issues/961