### PR TITLE
Improve deprecation warning for Record.Value

### DIFF
--- a/provider/cmd/pulumi-resource-cloudflare/schema.json
+++ b/provider/cmd/pulumi-resource-cloudflare/schema.json
@@ -24425,7 +24425,7 @@
                 "value": {
                     "type": "string",
                     "description": "The value of the record. Must provide only one of `data`, `content`, `value`.\n",
-                    "deprecationMessage": "`value` is deprecated in favour of `content` and will be removed in the next major release."
+                    "deprecationMessage": "`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`."
                 },
                 "zoneId": {
                     "type": "string",
@@ -24493,7 +24493,7 @@
                 "value": {
                     "type": "string",
                     "description": "The value of the record. Must provide only one of `data`, `content`, `value`.\n",
-                    "deprecationMessage": "`value` is deprecated in favour of `content` and will be removed in the next major release."
+                    "deprecationMessage": "`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`."
                 },
                 "zoneId": {
                     "type": "string",
@@ -24579,7 +24579,7 @@
                     "value": {
                         "type": "string",
                         "description": "The value of the record. Must provide only one of `data`, `content`, `value`.\n",
-                        "deprecationMessage": "`value` is deprecated in favour of `content` and will be removed in the next major release."
+                        "deprecationMessage": "`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`."
                     },
                     "zoneId": {
                         "type": "string",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -136,7 +136,17 @@ func Provider() info.Provider {
 			// If `type` or `zoneId` is changed, then the resource will replace but the new
 			// resource will conflict with the old one. To avoid this, we set
 			// `DeleteBeforeReplace: true`.
-			"cloudflare_record": {DeleteBeforeReplace: true},
+			"cloudflare_record": {
+				DeleteBeforeReplace: true,
+				Fields: map[string]*info.Schema{
+					"value": {
+						DeprecationMessage: "`value` is deprecated in favour of `content` " +
+							"and will be removed in the next major release. " +
+							"Due to reports of inconsistent behavior on the `value` field, " +
+							"we strongly recommend migrating to `content`.",
+					},
+				},
+			},
 
 			"cloudflare_risk_behavior":                            {ComputeID: delegateID("accountId")},
 			"cloudflare_zero_trust_access_mtls_hostname_settings": {ComputeID: delegateID("accountId")},

--- a/sdk/go/cloudflare/record.go
+++ b/sdk/go/cloudflare/record.go
@@ -102,7 +102,7 @@ type Record struct {
 	Type pulumi.StringOutput `pulumi:"type"`
 	// The value of the record. Must provide only one of `data`, `content`, `value`.
 	//
-	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.
+	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
 	Value pulumi.StringOutput `pulumi:"value"`
 	// The zone identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
 	ZoneId pulumi.StringOutput `pulumi:"zoneId"`
@@ -178,7 +178,7 @@ type recordState struct {
 	Type *string `pulumi:"type"`
 	// The value of the record. Must provide only one of `data`, `content`, `value`.
 	//
-	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.
+	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
 	Value *string `pulumi:"value"`
 	// The zone identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
 	ZoneId *string `pulumi:"zoneId"`
@@ -216,7 +216,7 @@ type RecordState struct {
 	Type pulumi.StringPtrInput
 	// The value of the record. Must provide only one of `data`, `content`, `value`.
 	//
-	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.
+	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
 	Value pulumi.StringPtrInput
 	// The zone identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
 	ZoneId pulumi.StringPtrInput
@@ -248,7 +248,7 @@ type recordArgs struct {
 	Type string `pulumi:"type"`
 	// The value of the record. Must provide only one of `data`, `content`, `value`.
 	//
-	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.
+	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
 	Value *string `pulumi:"value"`
 	// The zone identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
 	ZoneId string `pulumi:"zoneId"`
@@ -277,7 +277,7 @@ type RecordArgs struct {
 	Type pulumi.StringInput
 	// The value of the record. Must provide only one of `data`, `content`, `value`.
 	//
-	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.
+	// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
 	Value pulumi.StringPtrInput
 	// The zone identifier to target for the resource. **Modifying this attribute will force creation of a new resource.**
 	ZoneId pulumi.StringInput
@@ -446,7 +446,7 @@ func (o RecordOutput) Type() pulumi.StringOutput {
 
 // The value of the record. Must provide only one of `data`, `content`, `value`.
 //
-// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.
+// Deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
 func (o RecordOutput) Value() pulumi.StringOutput {
 	return o.ApplyT(func(v *Record) pulumi.StringOutput { return v.Value }).(pulumi.StringOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/cloudflare/Record.java
+++ b/sdk/java/src/main/java/com/pulumi/cloudflare/Record.java
@@ -294,10 +294,10 @@ public class Record extends com.pulumi.resources.CustomResource {
      * The value of the record. Must provide only one of `data`, `content`, `value`.
      * 
      * @deprecated
-     * `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      * 
      */
-    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
     @Export(name="value", refs={String.class}, tree="[0]")
     private Output<String> value;
 

--- a/sdk/java/src/main/java/com/pulumi/cloudflare/RecordArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/cloudflare/RecordArgs.java
@@ -166,10 +166,10 @@ public final class RecordArgs extends com.pulumi.resources.ResourceArgs {
      * The value of the record. Must provide only one of `data`, `content`, `value`.
      * 
      * @deprecated
-     * `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      * 
      */
-    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
     @Import(name="value")
     private @Nullable Output<String> value;
 
@@ -177,10 +177,10 @@ public final class RecordArgs extends com.pulumi.resources.ResourceArgs {
      * @return The value of the record. Must provide only one of `data`, `content`, `value`.
      * 
      * @deprecated
-     * `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      * 
      */
-    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
     public Optional<Output<String>> value() {
         return Optional.ofNullable(this.value);
     }
@@ -449,10 +449,10 @@ public final class RecordArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          * @deprecated
-         * `value` is deprecated in favour of `content` and will be removed in the next major release.
+         * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
          * 
          */
-        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
         public Builder value(@Nullable Output<String> value) {
             $.value = value;
             return this;
@@ -464,10 +464,10 @@ public final class RecordArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          * @deprecated
-         * `value` is deprecated in favour of `content` and will be removed in the next major release.
+         * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
          * 
          */
-        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
         public Builder value(String value) {
             return value(Output.of(value));
         }

--- a/sdk/java/src/main/java/com/pulumi/cloudflare/inputs/RecordState.java
+++ b/sdk/java/src/main/java/com/pulumi/cloudflare/inputs/RecordState.java
@@ -241,10 +241,10 @@ public final class RecordState extends com.pulumi.resources.ResourceArgs {
      * The value of the record. Must provide only one of `data`, `content`, `value`.
      * 
      * @deprecated
-     * `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      * 
      */
-    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
     @Import(name="value")
     private @Nullable Output<String> value;
 
@@ -252,10 +252,10 @@ public final class RecordState extends com.pulumi.resources.ResourceArgs {
      * @return The value of the record. Must provide only one of `data`, `content`, `value`.
      * 
      * @deprecated
-     * `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      * 
      */
-    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+    @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
     public Optional<Output<String>> value() {
         return Optional.ofNullable(this.value);
     }
@@ -634,10 +634,10 @@ public final class RecordState extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          * @deprecated
-         * `value` is deprecated in favour of `content` and will be removed in the next major release.
+         * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
          * 
          */
-        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
         public Builder value(@Nullable Output<String> value) {
             $.value = value;
             return this;
@@ -649,10 +649,10 @@ public final class RecordState extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          * @deprecated
-         * `value` is deprecated in favour of `content` and will be removed in the next major release.
+         * `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
          * 
          */
-        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. */
+        @Deprecated /* `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`. */
         public Builder value(String value) {
             return value(Output.of(value));
         }

--- a/sdk/nodejs/record.ts
+++ b/sdk/nodejs/record.ts
@@ -134,7 +134,7 @@ export class Record extends pulumi.CustomResource {
     /**
      * The value of the record. Must provide only one of `data`, `content`, `value`.
      *
-     * @deprecated `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * @deprecated `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      */
     public readonly value!: pulumi.Output<string>;
     /**
@@ -270,7 +270,7 @@ export interface RecordState {
     /**
      * The value of the record. Must provide only one of `data`, `content`, `value`.
      *
-     * @deprecated `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * @deprecated `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      */
     value?: pulumi.Input<string>;
     /**
@@ -323,7 +323,7 @@ export interface RecordArgs {
     /**
      * The value of the record. Must provide only one of `data`, `content`, `value`.
      *
-     * @deprecated `value` is deprecated in favour of `content` and will be removed in the next major release.
+     * @deprecated `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.
      */
     value?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_cloudflare/record.py
+++ b/sdk/python/pulumi_cloudflare/record.py
@@ -67,8 +67,8 @@ class RecordArgs:
         if ttl is not None:
             pulumi.set(__self__, "ttl", ttl)
         if value is not None:
-            warnings.warn("""`value` is deprecated in favour of `content` and will be removed in the next major release.""", DeprecationWarning)
-            pulumi.log.warn("""value is deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.""")
+            warnings.warn("""`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""", DeprecationWarning)
+            pulumi.log.warn("""value is deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""")
         if value is not None:
             pulumi.set(__self__, "value", value)
 
@@ -203,7 +203,7 @@ class RecordArgs:
 
     @property
     @pulumi.getter
-    @_utilities.deprecated("""`value` is deprecated in favour of `content` and will be removed in the next major release.""")
+    @_utilities.deprecated("""`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""")
     def value(self) -> Optional[pulumi.Input[str]]:
         """
         The value of the record. Must provide only one of `data`, `content`, `value`.
@@ -285,8 +285,8 @@ class _RecordState:
         if type is not None:
             pulumi.set(__self__, "type", type)
         if value is not None:
-            warnings.warn("""`value` is deprecated in favour of `content` and will be removed in the next major release.""", DeprecationWarning)
-            pulumi.log.warn("""value is deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release.""")
+            warnings.warn("""`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""", DeprecationWarning)
+            pulumi.log.warn("""value is deprecated: `value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""")
         if value is not None:
             pulumi.set(__self__, "value", value)
         if zone_id is not None:
@@ -471,7 +471,7 @@ class _RecordState:
 
     @property
     @pulumi.getter
-    @_utilities.deprecated("""`value` is deprecated in favour of `content` and will be removed in the next major release.""")
+    @_utilities.deprecated("""`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""")
     def value(self) -> Optional[pulumi.Input[str]]:
         """
         The value of the record. Must provide only one of `data`, `content`, `value`.
@@ -861,7 +861,7 @@ class Record(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    @_utilities.deprecated("""`value` is deprecated in favour of `content` and will be removed in the next major release.""")
+    @_utilities.deprecated("""`value` is deprecated in favour of `content` and will be removed in the next major release. Due to reports of inconsistent behavior on the `value` field, we strongly recommend migrating to `content`.""")
     def value(self) -> pulumi.Output[str]:
         """
         The value of the record. Must provide only one of `data`, `content`, `value`.


### PR DESCRIPTION
In partial assist for https://github.com/pulumi/pulumi-cloudflare/issues/952.

Due to not having a reliable repro of #952, we update the deprecation warning on Record.Value to be more explicit about updating to the new field.

This pull request is blocked on the next bridge release as it needs changes from https://github.com/pulumi/pulumi-terraform-bridge/pull/2746.
