### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -251,6 +251,7 @@ func Provider() info.Provider {
 			},
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	prov.MustComputeTokens(tfbridgetokens.SingleModule("cloudflare_", mainMod,


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the pulumi-cloudflare provider. This should improve the quality of our previews for the provider.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598