### PR TITLE
Pull bridge fix for nil runtime ids

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.23.3
 require (
 	github.com/cloudflare/terraform-provider-cloudflare v1.18.2-0.20220823222840-b2cee3be8c57
 	github.com/pulumi/providertest v0.2.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.106.1-0.20250411112232-65d5aaa8a76e
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.106.1-0.20250416142950-9ff35dbdae81
 	github.com/pulumi/pulumi/sdk/v3 v3.162.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -765,6 +765,8 @@ github.com/pulumi/pulumi-java/pkg v1.8.0 h1:xCTQqTGxDj1f+VmCR//V0x355rAkc2b2VCIi
 github.com/pulumi/pulumi-java/pkg v1.8.0/go.mod h1:VH4YGMcPEYuMyOJjohMTepAqPSFPgmz4I3U4q5sJ89o=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.106.1-0.20250411112232-65d5aaa8a76e h1:MUoPznYPWZPD5IU6plDcrBcmMeHkZBTnZEojZFALlX0=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.106.1-0.20250411112232-65d5aaa8a76e/go.mod h1:ccXIx12+uLsel7+XVw9G47XV5HtkVlUmmBkfEFAuStI=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.106.1-0.20250416142950-9ff35dbdae81 h1:e7pG4lRE3PyUc6JqwtkemAknqrSj+BomyPMqO7+DAos=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.106.1-0.20250416142950-9ff35dbdae81/go.mod h1:ccXIx12+uLsel7+XVw9G47XV5HtkVlUmmBkfEFAuStI=
 github.com/pulumi/pulumi-yaml v1.15.1 h1:4T36uwbJlQMbcK/X3U9BuqMZFEN4lnAIysPtqDvm0Tg=
 github.com/pulumi/pulumi-yaml v1.15.1/go.mod h1:J3HzbFVhR7sOsZQT7nztBgetcCbxFkOeOMvZDkQs0IU=
 github.com/pulumi/pulumi/pkg/v3 v3.162.0 h1:o8XbI2MpywlAnXKhRChtLMA8I0XkBD6wUDX5wNwMs4o=

--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -119,3 +119,8 @@ func TestWorkersRoute(t *testing.T) {
 	pt := testProgram(t, "test-programs/workers_route")
 	pt.Up(t)
 }
+
+func TestZoneSettings(t *testing.T) {
+	pt := testProgram(t, "test-programs/zonesettings")
+	pt.Up(t)
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -301,6 +301,9 @@ func Provider() info.Provider {
 					return outputs, nil
 				},
 			},
+			"cloudflare_zone_setting": {
+				ComputeID: delegateID("settingId"),
+			},
 		},
 		DataSources: map[string]*info.DataSource{},
 		JavaScript: &tfbridge.JavaScriptInfo{
@@ -370,7 +373,6 @@ func Provider() info.Provider {
 		"cloudflare_logpush_job",
 		"cloudflare_magic_network_monitoring_rule",
 		"cloudflare_image_variant",
-		"cloudflare_zone_setting",
 		"cloudflare_turnstile_widget",
 	}
 

--- a/provider/test-programs/zonesettings/Pulumi.yaml
+++ b/provider/test-programs/zonesettings/Pulumi.yaml
@@ -1,0 +1,12 @@
+runtime: yaml
+name: zone-settings
+config:
+  cloudflare-zone-id:
+    type: string
+resources:
+  ssl-settings:
+    type: cloudflare:ZoneSetting
+    properties:
+      zoneId: ${cloudflare-zone-id}
+      settingId: ssl
+      value: strict


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi-cloudflare/issues/1127, the ZoneSetting resource seems to return a nil runtime ID. This PR pulls in the bridge fix (https://github.com/pulumi/pulumi-terraform-bridge/pull/3000) for this and any other resources which might have such inconsistent behaviour. This should prevent any other panics like that

fixes https://github.com/pulumi/pulumi-cloudflare/issues/1140