### PR TITLE
Reenable record refresh tests

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -15,7 +15,6 @@ func TestAccRecordCSharp(t *testing.T) {
 	test := getCsharpBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "record", "csharp"),
-			ExpectRefreshChanges: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -15,7 +15,6 @@ func TestAccRecordTs(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "record", "ts"),
-			ExpectRefreshChanges: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -15,7 +15,6 @@ func TestAccRecordPy(t *testing.T) {
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "record", "python"),
-			ExpectRefreshChanges: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/record/csharp/MyStack.cs
+++ b/examples/record/csharp/MyStack.cs
@@ -17,7 +17,7 @@ class MyStack : Stack
 
         var foobar = new Cloudflare.DnsRecord("foobar", new Cloudflare.DnsRecordArgs
         {
-            Name = "my-record-csharp",
+            Name = zone.Name.Apply(name => $"my-record-csharp.{name}"),
             ZoneId = zone.Id,
             Content = "162.168.0.14",
             Type = "A",

--- a/examples/record/python/__main__.py
+++ b/examples/record/python/__main__.py
@@ -11,7 +11,7 @@ zone = cloudflare.Zone(
 
 record = cloudflare.DnsRecord(
     "my-record-py",
-    name="my-record-py",
+    name=zone.name.apply(lambda name: f"my-record-py.{name}"),
     zone_id=zone.id,
     type="A",
     content="192.168.0.11",

--- a/examples/record/python/requirements.txt
+++ b/examples/record/python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-cloudflare>=3.0.0,<4.0.0
+pulumi-cloudflare>=6.0.0,<7.0.0

--- a/examples/record/ts/index.ts
+++ b/examples/record/ts/index.ts
@@ -10,7 +10,7 @@ const zone = new cloudflare.Zone("my-zone", {
 });
 
 new cloudflare.Record("my-record", {
-    name: "my-record-ts",
+    name: zone.name.apply(name => `my-record-ts.${name}`),
     zoneId: zone.id,
     type: "A",
     content: "192.168.0.11",

--- a/examples/record/ts/package.json
+++ b/examples/record/ts/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/cloudflare": "^5.0.0"
+    "@pulumi/cloudflare": "^6.0.0"
   }
 }

--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -108,8 +109,7 @@ func TestAccRecordGo(t *testing.T) {
 	pt := testProgram(t, "test-programs/recordgo",
 		opttest.GoModReplacement("github.com/pulumi/pulumi-cloudflare/sdk/v6", "..", "sdk"))
 	pt.Up(t)
-	// TODO[pulumi/pulumi-cloudflare#1120]: Dirty refresh on record
-	// pt.Refresh(t, optrefresh.ExpectNoChanges())
+	pt.Refresh(t, optrefresh.ExpectNoChanges(), optrefresh.Diff())
 	pt.Up(t, optup.ExpectNoChanges())
 }
 


### PR DESCRIPTION
The DnsRecord resource refreshed dirty last week but seems to be fixed today. I suspect something upstream was changed.

This PR re-enables the tests.

Related to https://github.com/pulumi/pulumi-cloudflare/issues/1120