### PR TITLE
Ensure DelegateID can handle numeric ID fields

### DIFF
--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,12 +1,14 @@
 package cloudflare
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-cloudflare/provider/v6/pkg/version"
@@ -32,23 +34,18 @@ func TestSchemaVersionsForResetResources(t *testing.T) {
 		if _, ok := foundMap[key]; !ok {
 			return true
 		}
-
-		errMsg := fmt.Sprintf(
-			"schema version is not 0 for %s. This resource might need an explicit migration since we are resetting its"+
-				" schema version. See https://github.com/pulumi/pulumi-cloudflare/issues/1156 for more details.",
-			key,
-		)
-		contract.Assertf(value.SchemaVersion() == 0, errMsg)
+		contract.Assertf(value.SchemaVersion() == 0, "schema version is not 0 for %s. "+
+			"This resource might need an explicit migration since we are resetting its"+
+			" schema version. "+
+			"See https://github.com/pulumi/pulumi-cloudflare/issues/1156 for more details.", key)
 		foundMap[key] = true
 		return true
 	})
 
 	for resName, found := range foundMap {
-		msg := fmt.Sprintf("Did not find resource %s in the provider for schema version resetting."+
-			" If the resource was renamed with an alias, then the reset needs to be applied to the new resource.",
-			resName,
-		)
-		contract.Assertf(found, msg)
+		contract.Assertf(found, "Did not find resource %s in the provider for schema version resetting."+
+			" If the resource was renamed with an alias, then the reset"+
+			" needs to be applied to the new resource.", resName)
 	}
 }
 
@@ -59,4 +56,43 @@ func TestRuleSetVersionReminder(t *testing.T) {
 	assert.Equalf(t, 0, r.SchemaVersion(), "Reminder: cloudflare_ruleset advanced schema version from 0 and "+
 		"custom Pulumi PreStateUpgradeHook that massaged provider=v5 resource=v1 version data needs to be "+
 		"revisited or possibly dropped")
+}
+
+func Test_delegateID(t *testing.T) {
+
+	type testCase struct {
+		name     string
+		idField  resource.PropertyKey
+		state    resource.PropertyMap
+		expectID resource.ID
+	}
+
+	testCases := []testCase{
+		{
+			name:    "simple-id",
+			idField: "id",
+			state: resource.PropertyMap{
+				"id": resource.NewStringProperty("my-resource"),
+			},
+			expectID: "my-resource",
+		},
+		{
+			name:    "numeric-id",
+			idField: "id",
+			state: resource.PropertyMap{
+				"id": resource.NewNumberProperty(42),
+			},
+			expectID: "42",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			d := delegateID(tc.idField)
+			result, err := d(ctx, tc.state)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectID, result)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1226

Resources such as cloudflare.LogpushJob have numeric ID fields defined in TF. Before this change the numeric fields could not be targeted by DelegateID to be re-interpreted as Pulumi-mandated special "ID". After the change, they can.

In addition to functional changes did a few edits to satisfy `make lint_provider` linter.