### PR TITLE
Fix ruleset rules migration

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -159,9 +159,12 @@ func Provider() info.Provider {
 
 							updatedApRules := resource.PropertyMap{}
 							for k, v := range apRulesMap {
-								if !v.IsString() {
+								if v.IsArray() {
 									updatedApRules[k] = v
 									continue
+								}
+								if !v.IsString() {
+									return r
 								}
 								ruleIds := strings.Split(v.StringValue(), ",")
 								ruleIdsArray := []resource.PropertyValue{}

--- a/provider/test-programs/ruleset_non_empty_rules/Pulumi.yaml
+++ b/provider/test-programs/ruleset_non_empty_rules/Pulumi.yaml
@@ -1,0 +1,25 @@
+name: example-ruleset
+runtime: yaml
+
+config:
+  cloudflare-zone-id:
+    type: string
+
+resources:
+  domain-rate-limit:
+    type: cloudflare:Ruleset
+    properties:
+      name: domain-rate-lmit
+      kind: zone
+      zoneId: ${cloudflare-zone-id}
+      phase: http_request_firewall_managed
+      rules:
+        - action: skip
+          actionParameters:
+            rules:
+              efb7b8c949ac4650a09736fc376e9aee:
+                - "ae20608d93b94e97988db1bbc12cf9c8"
+                - "ce11be543594412bb4bb92516aa0bef8"
+          enabled: true
+          expression: '(http.request.uri.path contains "/api/auth/callback")'
+

--- a/provider/testdata/ruleset_state.json
+++ b/provider/testdata/ruleset_state.json
@@ -1,0 +1,141 @@
+{
+    "version": 3,
+    "deployment": {
+      "manifest": {
+        "time": "2025-05-05T17:10:59.375919-04:00",
+        "magic": "e6c0aa7069a791ee1f5f0134b2e4d3fd2a33895ac173f4930f09ed56065602cb",
+        "version": "v3.167.0"
+      },
+      "secrets_providers": {
+        "type": "passphrase",
+        "state": {
+          "salt": "v1:O1t5suqMRIo=:v1:7DqVMCoY+uij+EZC:Bc3SzKdajmbRZU5OXZWfP0oEcpUIJw=="
+        }
+      },
+      "resources": [
+        {
+          "urn": "urn:pulumi:test::example-ruleset::pulumi:pulumi:Stack::example-ruleset-test",
+          "custom": false,
+          "type": "pulumi:pulumi:Stack",
+          "created": "2025-05-05T21:10:57.857411Z",
+          "modified": "2025-05-05T21:10:57.857411Z"
+        },
+        {
+          "urn": "urn:pulumi:test::example-ruleset::pulumi:providers:cloudflare::default",
+          "custom": true,
+          "id": "cb0e5542-6869-4d60-9efa-6b3f0b60fa3f",
+          "type": "pulumi:providers:cloudflare",
+          "inputs": {
+            "apiClientLogging": "false",
+            "maxBackoff": "30",
+            "minBackoff": "1",
+            "retries": "3",
+            "rps": "4"
+          },
+          "outputs": {
+            "apiClientLogging": "false",
+            "maxBackoff": "30",
+            "minBackoff": "1",
+            "retries": "3",
+            "rps": "4"
+          },
+          "created": "2025-05-05T21:10:57.873539Z",
+          "modified": "2025-05-05T21:10:57.873539Z"
+        },
+        {
+          "urn": "urn:pulumi:test::example-ruleset::cloudflare:index/ruleset:Ruleset::domain-rate-limit",
+          "custom": true,
+          "id": "bc1de1301d044b5db8f77c4f6056d697",
+          "type": "cloudflare:index/ruleset:Ruleset",
+          "inputs": {
+            "kind": "zone",
+            "name": "domain-rate-lmit",
+            "phase": "http_request_transform",
+            "rules": [
+              {
+                "action": "rewrite",
+                "actionParameters": {
+                  "uri": {
+                    "path": {
+                      "value": "/my-new-route"
+                    }
+                  }
+                },
+                "enabled": true,
+                "expression": "(http.host eq \"example.com\" and http.request.uri.path eq \"/old-path\")"
+              },
+              {
+                "action": "skip",
+                "actionParameters": {
+                  "rules": {
+                    "efb7b8c949ac4650a09736fc376e9aee": "ae20608d93b94e97988db1bbc12cf9c8,ce11be543594412bb4bb92516aa0bef8"
+                  }
+                },
+                "description": "Bypass partners on Google/Bing bot rule",
+                "enabled": true,
+                "expression": "(ip.src in {<ip list redacted>})"
+              }
+            ],
+            "zoneId": "cabcdb3c8548af2e275acc42ed1fea45"
+          },
+          "outputs": {
+            "__meta": "{\"schema_version\":\"1\"}",
+            "description": "",
+            "id": "bc1de1301d044b5db8f77c4f6056d697",
+            "kind": "zone",
+            "name": "domain-rate-lmit",
+            "phase": "http_request_transform",
+            "rules": [
+              {
+                "action": "rewrite",
+                "actionParameters": {
+                  "algorithms": [],
+                  "autominifies": [],
+                  "headers": [],
+                  "responses": [],
+                  "uri": {
+                    "path": {
+                      "value": "/my-new-route"
+                    }
+                  }
+                },
+                "description": "",
+                "enabled": true,
+                "expression": "(http.host eq \"example.com\" and http.request.uri.path eq \"/old-path\")",
+                "id": "2db3848bb320472082ab27c17517864a",
+                "ref": "2db3848bb320472082ab27c17517864a"
+              },
+              {
+                "action": "skip",
+                "actionParameters": {
+                  "algorithms": [],
+                  "autominifies": [],
+                  "headers": [],
+                  "responses": [],
+                  "rules": {
+                    "efb7b8c949ac4650a09736fc376e9aee": "ae20608d93b94e97988db1bbc12cf9c8,ce11be543594412bb4bb92516aa0bef8"
+                  }
+                },
+                "description": "Bypass partners on Google/Bing bot rule",
+                "enabled": true,
+                "expression": "(ip.src in {<ip list redacted>})"
+              }
+            ],
+            "zoneId": "cabcdb3c8548af2e275acc42ed1fea45"
+          },
+          "parent": "urn:pulumi:test::example-ruleset::pulumi:pulumi:Stack::example-ruleset-test",
+          "provider": "urn:pulumi:test::example-ruleset::pulumi:providers:cloudflare::default::cb0e5542-6869-4d60-9efa-6b3f0b60fa3f",
+          "propertyDependencies": {
+            "kind": [],
+            "name": [],
+            "phase": [],
+            "rules": [],
+            "zoneId": []
+          },
+          "created": "2025-05-05T21:10:59.372981Z",
+          "modified": "2025-05-05T21:10:59.372981Z"
+        }
+      ],
+      "metadata": {}
+    }
+  }


### PR DESCRIPTION
The `rules` property within the `actionParameter` property was changed from `map[string]string` into `map[string][]string` upstream but without a migration. This adds that missing migration so users don't hit issues with it.

I have not managed to actually create a resource with the properties in question but have reproduced the issue with a state a user provided. I've added the test here.

fixes https://github.com/pulumi/pulumi-cloudflare/issues/1213