### PR TITLE
Fix ruleset rules for older providers

### DIFF
--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -146,13 +146,21 @@ func TestZoneSettings(t *testing.T) {
 
 // Regression test for [pulumi/pulumi-cloudflare#1213]
 func TestRuleSetNonEmptyRulesUpgrade(t *testing.T) {
-	state, err := os.ReadFile("testdata/ruleset_state.json")
-	require.NoError(t, err)
-	depl := apitype.UntypedDeployment{}
-	err = json.Unmarshal(state, &depl)
-	require.NoError(t, err)
-	pt := testProgram(t, "test-programs/ruleset_non_empty_rules",
-		opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
-	pt.ImportStack(t, depl)
-	pt.Preview(t)
+	for _, stateFile := range []string{
+		"testdata/ruleset_state_v6.json",
+		"testdata/ruleset_state_v5.json",
+		"testdata/ruleset_state_v4.json",
+	} {
+		t.Run(stateFile, func(t *testing.T) {
+			state, err := os.ReadFile(stateFile)
+			require.NoError(t, err)
+			depl := apitype.UntypedDeployment{}
+			err = json.Unmarshal(state, &depl)
+			require.NoError(t, err)
+			pt := testProgram(t, "test-programs/ruleset_non_empty_rules",
+				opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
+			pt.ImportStack(t, depl)
+			pt.Preview(t)
+		})
+	}
 }

--- a/provider/test-programs/ruleset_non_empty_rules/Pulumi.yaml
+++ b/provider/test-programs/ruleset_non_empty_rules/Pulumi.yaml
@@ -6,13 +6,14 @@ config:
     type: string
 
 resources:
-  domain-rate-limit:
+  ManagedRulesets:
     type: cloudflare:Ruleset
     properties:
-      name: domain-rate-lmit
+      name: Managed WAF Rulesets
       kind: zone
       zoneId: ${cloudflare-zone-id}
       phase: http_request_firewall_managed
+      description: description
       rules:
         - action: skip
           actionParameters:
@@ -21,5 +22,5 @@ resources:
                 - "ae20608d93b94e97988db1bbc12cf9c8"
                 - "ce11be543594412bb4bb92516aa0bef8"
           enabled: true
-          expression: '(http.request.uri.path contains "/api/auth/callback")'
-
+          expression: '(ip.src in {10.1.1.1})'
+          description: Bypass partners on Google/Bing bot rule

--- a/provider/testdata/ruleset_state_v4.json
+++ b/provider/testdata/ruleset_state_v4.json
@@ -1,0 +1,124 @@
+{
+    "version": 3,
+    "deployment": {
+      "manifest": {
+        "time": "2025-05-05T17:10:59.375919-04:00",
+        "magic": "e6c0aa7069a791ee1f5f0134b2e4d3fd2a33895ac173f4930f09ed56065602cb",
+        "version": "v3.167.0"
+      },
+      "secrets_providers": {
+        "type": "passphrase",
+        "state": {
+          "salt": "v1:O1t5suqMRIo=:v1:7DqVMCoY+uij+EZC:Bc3SzKdajmbRZU5OXZWfP0oEcpUIJw=="
+        }
+      },
+      "resources": [
+        {
+          "urn": "urn:pulumi:test::example-ruleset::pulumi:pulumi:Stack::example-ruleset-test",
+          "custom": false,
+          "type": "pulumi:pulumi:Stack",
+          "created": "2025-05-05T21:10:57.857411Z",
+          "modified": "2025-05-05T21:10:57.857411Z"
+        },
+        {
+          "urn": "urn:pulumi:test::example-ruleset::pulumi:providers:cloudflare::default",
+          "custom": true,
+          "id": "cb0e5542-6869-4d60-9efa-6b3f0b60fa3f",
+          "type": "pulumi:providers:cloudflare",
+          "inputs": {
+            "apiClientLogging": "false",
+            "maxBackoff": "30",
+            "minBackoff": "1",
+            "retries": "3",
+            "rps": "4"
+          },
+          "outputs": {
+            "apiClientLogging": "false",
+            "maxBackoff": "30",
+            "minBackoff": "1",
+            "retries": "3",
+            "rps": "4"
+          },
+          "created": "2025-05-05T21:10:57.873539Z",
+          "modified": "2025-05-05T21:10:57.873539Z"
+        },
+        {
+          "urn": "urn:pulumi:test::example-ruleset::cloudflare:index/ruleset:Ruleset::ManagedRulesets",
+          "custom": true,
+          "id": "bc1de1301d044b5db8f77c4f6056d697",
+          "type": "cloudflare:index/ruleset:Ruleset",
+          "inputs": {
+            "kind": "zone",
+            "name": "Managed WAF Rulesets",
+            "phase": "http_request_firewall_managed",
+            "description": "description",
+            "rules": [
+                {
+                    "__defaults": [],
+                    "action": "skip",
+                    "actionParameters": {
+                        "__defaults": [],
+                        "rules": {
+                            "__defaults": [],
+                            "efb7b8c949ac4650a09736fc376e9aee": "ae20608d93b94e97988db1bbc12cf9c8,ce11be543594412bb4bb92516aa0bef8"
+                        }
+                    },
+                    "description": "Bypass partners on Google/Bing bot rule",
+                    "enabled": true,
+                    "expression": "(ip.src in {10.1.1.1})"
+                }
+            ],
+            "zoneId": "cabcdb3c8548af2e275acc42ed1fea45"
+          },
+          "outputs": {
+                "description": "description",
+                "id": "eba9ea086bf04ef5b507196808f87f7a",
+                "kind": "zone",
+                "name": "Managed WAF Rulesets",
+                "phase": "http_request_firewall_managed",
+                "rules": [
+                    {
+                        "action": "skip",
+                        "actionParameters": {
+                            "headers": [],
+                            "id": "",
+                            "increment": 0,
+                            "matchedData": null,
+                            "overrides": null,
+                            "products": [],
+                            "rules": {
+                                "efb7b8c949ac4650a09736fc376e9aee": "ae20608d93b94e97988db1bbc12cf9c8,ce11be543594412bb4bb92516aa0bef8"
+                            },
+                            "ruleset": "",
+                            "rulesets": [],
+                            "uri": null,
+                            "version": ""
+                        },
+                        "description": "Bypass partners on Google/Bing bot rule",
+                        "enabled": true,
+                        "exposedCredentialCheck": null,
+                        "expression": "(ip.src in {10.1.1.1})",
+                        "id": "cb843ea30f2842b49d4801065514795f",
+                        "ratelimit": null,
+                        "ref": "",
+                        "version": ""
+                    }
+                ],
+                "zoneId": "cabcdb3c8548af2e275acc42ed1fea45"
+            },
+          "parent": "urn:pulumi:test::example-ruleset::pulumi:pulumi:Stack::example-ruleset-test",
+          "provider": "urn:pulumi:test::example-ruleset::pulumi:providers:cloudflare::default::cb0e5542-6869-4d60-9efa-6b3f0b60fa3f",
+          "propertyDependencies": {
+            "kind": [],
+            "name": [],
+            "phase": [],
+            "rules": [],
+            "zoneId": []
+          },
+          "created": "2025-05-05T21:10:59.372981Z",
+          "modified": "2025-05-05T21:10:59.372981Z"
+        }
+      ],
+      "metadata": {}
+    }
+  }

--- a/provider/testdata/ruleset_state_v5.json
+++ b/provider/testdata/ruleset_state_v5.json
@@ -43,14 +43,15 @@
           "modified": "2025-05-05T21:10:57.873539Z"
         },
         {
-          "urn": "urn:pulumi:test::example-ruleset::cloudflare:index/ruleset:Ruleset::domain-rate-limit",
+          "urn": "urn:pulumi:test::example-ruleset::cloudflare:index/ruleset:Ruleset::ManagedRulesets",
           "custom": true,
           "id": "bc1de1301d044b5db8f77c4f6056d697",
           "type": "cloudflare:index/ruleset:Ruleset",
           "inputs": {
             "kind": "zone",
-            "name": "domain-rate-lmit",
-            "phase": "http_request_transform",
+            "name": "Managed WAF Rulesets",
+            "phase": "http_request_firewall_managed",
+            "description": "description",
             "rules": [
               {
                 "action": "rewrite",
@@ -80,11 +81,11 @@
           },
           "outputs": {
             "__meta": "{\"schema_version\":\"1\"}",
-            "description": "",
             "id": "bc1de1301d044b5db8f77c4f6056d697",
             "kind": "zone",
-            "name": "domain-rate-lmit",
-            "phase": "http_request_transform",
+            "name": "Managed WAF Rulesets",
+            "phase": "http_request_firewall_managed",
+            "description": "description",
             "rules": [
               {
                 "action": "rewrite",

--- a/provider/testdata/ruleset_state_v6.json
+++ b/provider/testdata/ruleset_state_v6.json
@@ -1,0 +1,113 @@
+{
+    "version": 3,
+    "deployment": {
+      "manifest": {
+        "time": "2025-05-05T17:10:59.375919-04:00",
+        "magic": "e6c0aa7069a791ee1f5f0134b2e4d3fd2a33895ac173f4930f09ed56065602cb",
+        "version": "v3.167.0"
+      },
+      "secrets_providers": {
+        "type": "passphrase",
+        "state": {
+          "salt": "v1:O1t5suqMRIo=:v1:7DqVMCoY+uij+EZC:Bc3SzKdajmbRZU5OXZWfP0oEcpUIJw=="
+        }
+      },
+      "resources": [
+        {
+          "urn": "urn:pulumi:test::example-ruleset::pulumi:pulumi:Stack::example-ruleset-test",
+          "custom": false,
+          "type": "pulumi:pulumi:Stack",
+          "created": "2025-05-05T21:10:57.857411Z",
+          "modified": "2025-05-05T21:10:57.857411Z"
+        },
+        {
+          "urn": "urn:pulumi:test::example-ruleset::pulumi:providers:cloudflare::default",
+          "custom": true,
+          "id": "cb0e5542-6869-4d60-9efa-6b3f0b60fa3f",
+          "type": "pulumi:providers:cloudflare",
+          "inputs": {
+            "apiClientLogging": "false",
+            "maxBackoff": "30",
+            "minBackoff": "1",
+            "retries": "3",
+            "rps": "4"
+          },
+          "outputs": {
+            "apiClientLogging": "false",
+            "maxBackoff": "30",
+            "minBackoff": "1",
+            "retries": "3",
+            "rps": "4"
+          },
+          "created": "2025-05-05T21:10:57.873539Z",
+          "modified": "2025-05-05T21:10:57.873539Z"
+        },
+        {
+          "urn": "urn:pulumi:test::example-ruleset::cloudflare:index/ruleset:Ruleset::ManagedRulesets",
+          "custom": true,
+          "id": "bc1de1301d044b5db8f77c4f6056d697",
+          "type": "cloudflare:index/ruleset:Ruleset",
+          "inputs": {
+            "kind": "zone",
+            "name": "Managed WAF Rulesets",
+            "phase": "http_request_firewall_managed",
+            "rules": [
+                {
+                    "action": "skip",
+                    "actionParameters": {
+                        "rules": {
+                            "efb7b8c949ac4650a09736fc376e9aee": [
+                                "ae20608d93b94e97988db1bbc12cf9c8",
+                                "ce11be543594412bb4bb92516aa0bef8"
+                            ]
+                        }
+                    },
+                    "description": "Bypass partners on Google/Bing bot rule",
+                    "enabled": true,
+                    "expression": "(ip.src in {10.1.1.1})"
+                }
+            ],
+            "zoneId": "cabcdb3c8548af2e275acc42ed1fea45"
+        },
+        "outputs": {
+            "description": "",
+            "id": "f41c5bb8e4894009aa64a0614f4dba38",
+            "kind": "zone",
+            "name": "Managed WAF Rulesets",
+            "phase": "http_request_firewall_managed",
+            "rules": [
+                {
+                    "action": "skip",
+                    "actionParameters": {
+                        "rules": {
+                            "efb7b8c949ac4650a09736fc376e9aee": [
+                                "ae20608d93b94e97988db1bbc12cf9c8",
+                                "ce11be543594412bb4bb92516aa0bef8"
+                            ]
+                        }
+                    },
+                    "description": "Bypass partners on Google/Bing bot rule",
+                    "enabled": true,
+                    "expression": "(ip.src in {10.1.1.1})",
+                    "id": "bd59873a41e94602b8ec039a9d062e4f",
+                    "ref": "bd59873a41e94602b8ec039a9d062e4f"
+                }
+            ],
+            "zoneId": "cabcdb3c8548af2e275acc42ed1fea45"
+        },
+          "parent": "urn:pulumi:test::example-ruleset::pulumi:pulumi:Stack::example-ruleset-test",
+          "provider": "urn:pulumi:test::example-ruleset::pulumi:providers:cloudflare::default::cb0e5542-6869-4d60-9efa-6b3f0b60fa3f",
+          "propertyDependencies": {
+            "kind": [],
+            "name": [],
+            "phase": [],
+            "rules": [],
+            "zoneId": []
+          },
+          "created": "2025-05-05T21:10:59.372981Z",
+          "modified": "2025-05-05T21:10:59.372981Z"
+        }
+      ],
+      "metadata": {}
+    }
+  }


### PR DESCRIPTION
The `Ruleset` resource had some type changes and no corresponding migration. We fixed this in https://github.com/pulumi/pulumi-cloudflare/pull/1244 but it only covered somewhat recent provider versions due to the resource version guard (post 2022 or so, v 4.10.0).

This PR removes the version guard and does the migration only based on the types of the properties in the state. This should cover all provider versions.

I've also added tests for a state from v4 and v6.

fixes https://github.com/pulumi/pulumi-cloudflare/pull/1244