### PR TITLE
Handle Zone `plan` output changing from string to object

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -216,6 +216,15 @@ func Provider() info.Provider {
 						)
 						delete(state, "accountId")
 					}
+
+					if plan, ok := state["plan"]; ok && plan.IsString() {
+						state["plan"] = resource.NewObjectProperty(
+							resource.PropertyMap{
+								"id": plan,
+							},
+						)
+					}
+
 					return state, nil
 				},
 			},

--- a/provider/testdata/recorded/TestProviderUpgrade/zonev5/5.49.0/stack.json
+++ b/provider/testdata/recorded/TestProviderUpgrade/zonev5/5.49.0/stack.json
@@ -116,6 +116,7 @@
           ],
           "paused": false,
           "status": "pending",
+          "plan": "free",
           "type": "full",
           "vanityNameServers": [],
           "verificationKey": "",


### PR DESCRIPTION
Upstream changed the `plan` property from a `string` to an `object` in
this [commit](https://github.com/cloudflare/terraform-provider-cloudflare/commit/9d82124eb6842d62fe627d6e06d2525843e2fc9a#diff-3c74b333096ccef44a6af68d2cd6283461b64a4a6a4399e54334739e11d8fe3c)
which was released in our v6.3.0.

This PR adds a state upgrade to convert it to an object if it is a
string.

fixes #1306